### PR TITLE
Run on dione

### DIFF
--- a/template.cu
+++ b/template.cu
@@ -94,13 +94,13 @@ void calculateOmega() {
     }
 }
 
-void printResult() {
-    printf("bin start/deg\t\tomega\t\thist_DD\t\thist_DR\t\thist_RR\n");
+void printResult( FILE *outfil ) {
+    fprintf( outfil, "bin start/deg\t\tomega\t\thist_DD\t\thist_DR\t\thist_RR\n");
     for( int i = 0; i < numBins; ++i ){
         if(histogramDD[i] == 0) {
             break;
         }
-        printf("%.3f\t\t%.6f\t\t%u\t\t%u\t\t%u\n", i * binWidth, omega[i], histogramDD[i], histogramDR[i], histogramRR[i] );
+        fprintf( outfil, "%.3f\t\t%.6f\t\t%u\t\t%u\t\t%u\n", i * binWidth, omega[i], histogramDD[i], histogramDR[i], histogramRR[i] );
     }
 }
 
@@ -165,7 +165,10 @@ int main(int argc, char *argv[])
 
    // calculate omega values on the CPU
    calculateOmega();
-   printResult();
+
+   outfil = fopen(argv[3], "w");
+   printResult(outfil);
+   fclose(outfil);
 
    cudaFree(ra_real_gm);
    cudaFree(decl_real_gm);

--- a/template.cu
+++ b/template.cu
@@ -49,7 +49,7 @@ __device__ float calculateAngularDistance(float g1_ra, float g1_dec, float g2_ra
 
     // calculate angular distance
     float delta_ra = ra2 - ra1;
-    float cos_c = sin(dec1) * sin(dec2) + cos(dec1) * cos(dec2) * cos(delta_ra);
+    float cos_c = sinf(dec1) * sinf(dec2) + cosf(dec1) * cosf(dec2) * cosf(delta_ra);
     if (cos_c > 1.0) {
         cos_c = 1.0;
     } else if (cos_c < -1.0) {


### PR DESCRIPTION
First of all, now it can be compiled and run on dione after fixing some errors;
and I tried to eliminate the loop in `calculateHistograms` by mapping the one-dimensional thread ID onto two-dimensional indices. A common way (from good old google 🙏) to do this is to use division and modulus operations, here I did `i = index / numD` and `j = index % numD` map the one-dimensional thread ID onto a two-dimensional pair (i, j). 
Let's say the `maxInputLength` is 4, then all the mapped indices are: 
```
(0, 0), (0, 1), (0, 2), (0, 3),
(1, 0), (1, 1), (1, 2), (1, 3),
(2, 0), (2, 1), (2, 2), (2, 3),
(3, 0), (3, 1), (3, 2), (3, 3)
```
And it seems to work.


Also, modify the printf with `outfil` pointer using fprintf, so that the result is saved in `omega.out`.....but the results looks a little bit wierd though......

haven't got idea about the wierd values in `omega.out` at lines around 20.000, the omega values are so large around 1000, don't know it that make sense.